### PR TITLE
ci: run tests only on pull requests, not push to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary

The Test workflow (`.github/workflows/lint.yml`) triggered on both `push` to `main` and `pull_request` to `main`. This caused the lint/test/build jobs to run twice for every merged PR — once on the PR and again on the resulting push to main.

This removes the `push` trigger, so tests run only on pull requests.

## Changes

- Drop `push.branches: [main]` from the Test workflow triggers, keeping `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)